### PR TITLE
Add script for counting special tiles.

### DIFF
--- a/bin/count_special
+++ b/bin/count_special
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+from astropy.table import Table
+
+
+def count_special_obs(exps):
+    m = exps['SURVEY'] == 'special'
+    flavors = np.unique(exps['FAFLAVOR'][m])
+    print(r'Program & Number of tiles & Number of exposures & '
+          r'Hours of effective time \\')
+    for flavor in flavors:
+        m = exps['FAFLAVOR'] == flavor
+        nexp = np.sum(m)
+        efftime = np.sum(exps['EFFTIME_SPEC'][m]) / 3600
+        ntile = len(np.unique(exps['TILEID'][m]))
+        program = flavor[len('special'):]
+        print(rf'{program:16s} & {ntile:3d} & {nexp:3d} & {efftime:5.1f} \\')
+    for flavor in flavors:
+        m = exps['FAFLAVOR'] == flavor
+        print(flavor, np.unique(exps['TILEID'][m].data))
+
+
+if __name__ == '__main__':
+    expfile = os.path.expandvars(
+       '$DESI_ROOT/spectro/redux/iron/exposures-iron.csv')
+    exps = Table.read(expfile)
+    count_special_obs(exps)


### PR DESCRIPTION
This is a short script to count the tiles for the "special" survey.  This script isn't great; in the actual paper, I fill out a bunch of other information (description, tileid) that would be annoying to script up.  This table is almost but not quite parallel to the main / sv / cmx table; I don't include the "area" column, and I do include a "tileid" column.  I wanted to be explicit about the tileid for this table, since they are the only things to use to describe what the different parts of the "special" program are doing.

It's possible that some version of TILEID would be nice for the main / sv / cmx table as well; we could at least say something like main/dark tiles fall in a particular TILEID range, etc., there.